### PR TITLE
deprecation fix: use new SCSS syntax

### DIFF
--- a/core/stylesheets/compass/css3/_deprecated-support.scss
+++ b/core/stylesheets/compass/css3/_deprecated-support.scss
@@ -84,14 +84,8 @@ $legacy-support-for-webkit: true !default;
 
 // A debug tool for checking browser support
 @mixin debug-support-matrix($experimental: true, $ie: true) {
-  @debug  #{'$moz-'}$experimental-support-for-mozilla
-          #{'$webkit-'}$experimental-support-for-webkit
-          #{'$opera-'}$experimental-support-for-opera
-          #{'$microsoft-'}$experimental-support-for-microsoft
-          #{'$khtml-'}$experimental-support-for-khtml;
-  @debug  #{'$ie6-'}$legacy-support-for-ie6
-          #{'$ie7-'}$legacy-support-for-ie7
-          #{'$ie8-'}$legacy-support-for-ie8;
+  @debug "#{$moz-}$experimental-support-for-mozilla #{$webkit-}$experimental-support-for-webkit #{$opera-}$experimental-support-for-opera #{$microsoft-}$experimental-support-for-microsoft #{$khtml-}$experimental-support-for-khtml";
+  @debug "#{$ie6-}$legacy-support-for-ie6 #{$ie7-}$legacy-support-for-ie7 #{$ie8-}$legacy-support-for-ie8";
 }
 
 // Capture the current exerimental support settings


### PR DESCRIPTION
Fixes deprecation warning with SASS and https://github.com/Compass/compass/issues/2052

```
DEPRECATION WARNING on line 92 of /Users/mattheworiordan/.rvm/gems/ruby-2.2.2/gems/compass-core-1.0.3/stylesheets/compass/css3/_deprecated-support.scss: #{} interpolation near operators will be simplified
in a future version of Sass. To preserve the current behavior, use quotes:

  unquote('"$ie6-"#{$legacy-support-for-ie6} "$ie7-"#{$legacy-support-for-ie7} "$ie8-"#{$legacy-support-for-ie8}')
```